### PR TITLE
Upgrade rack to version 1.6.12 or later

### DIFF
--- a/pizaid-controller.gemspec
+++ b/pizaid-controller.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.5"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rake", ">= 1.6.12"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency 'pry'
 


### PR DESCRIPTION
I'm not sure we have to maintain this repository, but the security mail from GitHub is annoying. So I've created this patch.

Running `bundle install` succeeded.

```console
$ sudo gem install bundler -v '1.5.3'
Fetching bundler-1.5.3.gem
Successfully installed bundler-1.5.3
Parsing documentation for bundler-1.5.3
Installing ri documentation for bundler-1.5.3
Done installing documentation for bundler after 1 seconds
1 gem installed
$ bundle install --path vendor/bundle
Fetching gem metadata from https://rubygems.org/........
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Fetching rake 13.0.1
Installing rake 13.0.1
Using bundler 1.17.2
Fetching coderay 1.1.2
Installing coderay 1.1.2
Fetching daemons 1.3.1
Installing daemons 1.3.1
Fetching diff-lcs 1.3
Installing diff-lcs 1.3
Fetching eventmachine 1.2.7
Installing eventmachine 1.2.7 with native extensions
Fetching ffi 1.12.2
Installing ffi 1.12.2 with native extensions
Fetching method_source 1.0.0
Installing method_source 1.0.0
Fetching rack 1.5.5
Installing rack 1.5.5
Fetching rb-inotify 0.10.1
Installing rb-inotify 0.10.1
Fetching thin 1.5.1
Installing thin 1.5.1 with native extensions
Fetching thrift 0.9.3.0
Installing thrift 0.9.3.0 with native extensions
Using pizaid-controller 0.0.1 from source at `.`
Fetching pry 0.13.1
Installing pry 0.13.1
Fetching rspec-support 3.9.2
Installing rspec-support 3.9.2
Fetching rspec-core 3.9.1
Installing rspec-core 3.9.1
Fetching rspec-expectations 3.9.1
Installing rspec-expectations 3.9.1
Fetching rspec-mocks 3.9.1
Installing rspec-mocks 3.9.1
Fetching rspec 3.9.0
Installing rspec 3.9.0
Bundle complete! 5 Gemfile dependencies, 19 gems now installed.
Bundled gems are installed into `./vendor/bundle`
```